### PR TITLE
fix hidding disabled downloader settings

### DIFF
--- a/static/css/settings/downloader.css
+++ b/static/css/settings/downloader.css
@@ -1,9 +1,12 @@
 div.card-body > div{
     overflow: hidden;
-    max-height: 0%;
-    transition: 0.6s;
+    max-height: 0;
+    transition: 0.6s cubic-bezier(0, 1, 0, 1);
 }
-
+div.card-body > div[data-enabled=True]{
+    max-height: 1000px;
+    transition: 0.6s ease;
+}
 
 div.card-body > div > div{
     margin-bottom: 1em;

--- a/static/js/settings/downloader.js
+++ b/static/js/settings/downloader.js
@@ -8,7 +8,6 @@ window.addEventListener("DOMContentLoaded", function(){
     // Set selects on page load
     each($usenet_clients, function(client){
         if(client.dataset.enabled == 'True'){
-            client.style.maxHeight = '100%';
             $select_usenet.value = client.id;
             return false;
         }
@@ -16,7 +15,6 @@ window.addEventListener("DOMContentLoaded", function(){
 
     each($torrent_clients, function(client){
         if(client.dataset.enabled == 'True'){
-            client.style.maxHeight = '100%';
             $select_torrent.value = client.id;
             return false;
         }
@@ -27,9 +25,9 @@ window.addEventListener("DOMContentLoaded", function(){
         each($usenet_clients, function(client){
 
             if(client.id == val){
-                client.style.maxHeight = '100%';
+                client.dataset.enabled = 'True';
             } else {
-                client.style.maxHeight = '0%';
+                client.dataset.enabled = 'False';
             }
         })
     });
@@ -37,9 +35,10 @@ window.addEventListener("DOMContentLoaded", function(){
     $select_torrent.addEventListener('change', function(event){
         var val = event.target.value;
         each($torrent_clients, function(client){
-            client.style.maxHeight = '0%';
             if(client.id == val){
-                client.style.maxHeight = '100%';
+                client.dataset.enabled = 'True';
+            } else {
+                client.dataset.enabled = 'False';
             }
         })
     });
@@ -106,7 +105,7 @@ function _get_settings(){
     each(document.querySelectorAll("div#usenet_client_settings > div"), function(client){
         var name = client.id;
         var config = {};
-        config['enabled'] = (client.style.maxHeight == '100%')
+        config['enabled'] = (client.dataset.enabled == 'True')
 
         each(client.querySelectorAll('i.c_box'), function(checkbox){
             config[checkbox.dataset.id] = is_checked(checkbox);
@@ -123,7 +122,7 @@ function _get_settings(){
     each(document.querySelectorAll("div#torrent_client_settings > div"), function(client){
         var name = client.id;
         var config = {};
-        config['enabled'] = (client.style.maxHeight == '100%')
+        config['enabled'] = (client.dataset.enabled == 'True')
 
         each(client.querySelectorAll('i.c_box'), function(checkbox){
             config[checkbox.dataset.id] = is_checked(checkbox);

--- a/templates/settings/downloader.html
+++ b/templates/settings/downloader.html
@@ -3,10 +3,10 @@
     <head>
         ${head}
         <script src="${url_base}/static/js/settings/shared.js?v=012" type="text/javascript"></script>
-        <script src="${url_base}/static/js/settings/downloader.js?v=013" type="text/javascript"></script>
+        <script src="${url_base}/static/js/settings/downloader.js?v=014" type="text/javascript"></script>
 
         <link href="${url_base}/static/css/settings/shared.css?v=010" rel="stylesheet">
-        <link href="${url_base}/static/css/settings/downloader.css?v=010" rel="stylesheet">
+        <link href="${url_base}/static/css/settings/downloader.css?v=011" rel="stylesheet">
     </head>
     <body>
         ${navbar}


### PR DESCRIPTION
use CSS on data-enabled attribute, and change dataset.enabled instead of setting and checking inline style in JS
fixes #42