### PR TITLE
Fix torrent download

### DIFF
--- a/core/providers/base.py
+++ b/core/providers/base.py
@@ -142,11 +142,14 @@ class NewzNabProvider(object):
                     if rt == qs == '':
                         guid = None
                     else:
-                        rt = rt + '?'
                         qsprs = urllib.parse.parse_qs(qs)
+                        params = []
+                        if 'xt' in qsprs:
+                            params.append('xt=' + qsprs.pop('xt')[0])
                         for k in qsprs:
-                            rt += '{}={}&'.format(k, urllib.parse.quote(qsprs[k][0]))
-                        guid = rt[:-1]
+                            for v in qsprs[k]:
+                                params.append('{}={}'.format(k, urllib.parse.quote(v)))
+                        guid = rt + '?' + '&'.join(params)
                 else:
                     guid = item.get('link')
 

--- a/core/providers/torrent.py
+++ b/core/providers/torrent.py
@@ -9,7 +9,7 @@ import logging
 logging = logging.getLogger(__name__)
 
 
-trackers = '&tr'.join(('udp://tracker.leechers-paradise.org:6969',
+trackers = '&tr='.join(('udp://tracker.leechers-paradise.org:6969',
                        'udp://zer0day.ch:1337',
                        'udp://tracker.coppersurfer.tk:6969',
                        'udp://public.popcorn-tracker.org:6969',
@@ -24,16 +24,17 @@ trackers = '&tr'.join(('udp://tracker.leechers-paradise.org:6969',
                        ))
 
 
-def magnet(hash_):
+def magnet(hash_, title):
     ''' Creates magnet link
     hash_ (str): base64 formatted torrent hash
+    title (str): name of the torrent
 
     Formats as magnet uri and adds trackers
 
     Returns str margnet uri
     '''
 
-    return 'magnet:?xt=urn:btih:{}&tr={}'.format(hash_, trackers)
+    return 'magnet:?xt=urn:btih:{}&dn={}&tr={}'.format(hash_, title, trackers)
 
 
 class Torrent(NewzNabProvider):

--- a/core/providers/torrent_modules/torrentdownloads.py
+++ b/core/providers/torrent_modules/torrentdownloads.py
@@ -76,7 +76,7 @@ def _parse(xml, imdbid):
             result['imdbid'] = imdbid
             result['indexer'] = 'TorrentDownloads'
             result['info_link'] = 'http://www.torrentdownloads.me{}'.format(i['link'])
-            result['torrentfile'] = core.providers.torrent.magnet(i['info_hash'])
+            result['torrentfile'] = core.providers.torrent.magnet(i['info_hash'], i['title'])
             result['guid'] = i['info_hash']
             result['type'] = 'magnet'
             result['downloadid'] = None

--- a/core/providers/torrent_modules/torrentz2.py
+++ b/core/providers/torrent_modules/torrentz2.py
@@ -80,7 +80,7 @@ def _parse(xml, imdbid):
             result['imdbid'] = imdbid
             result['indexer'] = 'Torrentz2'
             result['info_link'] = i['link']
-            result['torrentfile'] = core.providers.torrent.magnet(hash_)
+            result['torrentfile'] = core.providers.torrent.magnet(hash_, i['title'])
             result['guid'] = hash_
             result['type'] = 'magnet'
             result['downloadid'] = None

--- a/core/providers/torrent_modules/yts.py
+++ b/core/providers/torrent_modules/yts.py
@@ -76,7 +76,7 @@ def _parse(movie, imdbid, title):
             result['imdbid'] = imdbid
             result['indexer'] = 'YTS'
             result['info_link'] = 'https://ag/movie/{}'.format(title.replace(' ', '-'))
-            result['torrentfile'] = core.providers.torrent.magnet(i['hash'])
+            result['torrentfile'] = core.providers.torrent.magnet(i['hash'], result['title'])
             result['guid'] = i['hash']
             result['type'] = 'magnet'
             result['downloadid'] = None
@@ -123,7 +123,7 @@ def _parse_rss(xml):
             result['indexer'] = 'YTS'
             result['info_link'] = i.find('link').text
             result['guid'] = i.find('enclosure').attrib['url'].split('/')[-1]
-            result['torrentfile'] = core.providers.torrent.magnet(result['guid'])
+            result['torrentfile'] = core.providers.torrent.magnet(result['guid'], result['title'])
             result['type'] = 'magnet'
             result['downloadid'] = None
             result['seeders'] = 5

--- a/core/snatcher.py
+++ b/core/snatcher.py
@@ -238,6 +238,13 @@ def snatch_torrent(data):
     if urllib.parse.urlparse(guid).netloc:
         # if guid is not a url and not hash we'll have to get the hash now
         guid_ = Torrent.get_hash(data['torrentfile'])
+        if not guid_:
+            # torrent url may redirect to magnet uri
+            guid_, magnet = Torrent.get_hash_and_magnet(data['torrentfile'])
+            if magnet:
+                data['torrentfile'] = magnet
+                core.sql.update('SEARCHRESULTS', 'torrentfile', magnet, 'guid', guid)
+
         if guid_:
             core.sql.update('SEARCHRESULTS', 'guid', guid_, 'guid', guid)
             guid = guid_


### PR DESCRIPTION
Torrent download was failing for some torznab sources from jackett (magnetdl, elitetorrent-biz).
Also, magnet for yts, torrentz2 and torrentdownloads was wrong, only first tracker was picked, and dn argument was missed, although it isn't mandatory, it's good to have, if torrent doesn't download you don't know what torrent is.