### PR TITLE
Make quick add form float

### DIFF
--- a/static/css/add_movie.css
+++ b/static/css/add_movie.css
@@ -32,6 +32,10 @@ ul#movies li{
 
 .card .add-movie-form{
     display: none;
+    width: 100%;
+    position: absolute;
+    top: 100%;
+    z-index: 1;
 }
 
 button.show_details{

--- a/static/js/add_movie.js
+++ b/static/js/add_movie.js
@@ -155,7 +155,7 @@ function populate_movie_select(){
 
 function add_movie_settings(event, button){
     event.preventDefault();
-    $contents = $(button).closest('div.btn-group').find('div.add-movie-form');
+    $contents = $(button).closest('div.card').find('div.add-movie-form');
     if($contents.is(':visible')){
         $contents.slideUp();
     } else {

--- a/templates/add_movie.html
+++ b/templates/add_movie.html
@@ -2,8 +2,8 @@
 <html>
     <head>
         ${head}
-        <link href="${url_base}/static/css/add_movie.css?v=012" rel="stylesheet">
-        <script src="${url_base}/static/js/add_movie.js?v=015" type="text/javascript"></script>
+        <link href="${url_base}/static/css/add_movie.css?v=013" rel="stylesheet">
+        <script src="${url_base}/static/js/add_movie.js?v=016" type="text/javascript"></script>
     </head>
     <body>
         ${navbar}
@@ -86,46 +86,44 @@
                 <div class="card">
                     <img src="{img_url}" class="card-img-top">
                     <div class='btn-group'>
-                        <div class="dropdown w-75">
-                            <button type="button" class="btn btn-secondary dropdown-toggle w-100 rounded-0" onclick="add_movie_settings(event, this)">
-                                ${_('Add')}
-                            </button>
-                            <div class="add-movie-form">
-                                <div>
-                                    <button type="button" class="quality_profile btn btn-secondary dropdown-toggle w-100 rounded-0" data-toggle="dropdown">
-                                        ${next((profile[0] for profile in profiles if profile[1]), _('Quality Profile'))}
-                                    </button>
-                                    <div class="dropdown-menu">
-                                        %for profile in profiles:
-                                        <a class="dropdown-item ${'mdi mdi-star' if profile[1] else ''}" href="#" onclick="select_item(event, this)">
-                                            ${profile[0]}
-                                        </a>
-                                        %endfor
-                                    </div>
-                                </div>
-                                <div>
-                                    <button type="button" class="category btn btn-secondary dropdown-toggle w-100 rounded-0" data-toggle="dropdown">
-                                        ${_('Default')}
-                                    </button>
-                                    <div class="dropdown-menu">
-                                        <a class="dropdown-item mdi mdi-star" href="#" onclick="select_item(event, this)">
-                                            ${_('Default')}
-                                        </a>
-                                        %for category in categories:
-                                        <a class="dropdown-item" href="#" onclick="select_item(event, this)">
-                                            ${category}
-                                        </a>
-                                        %endfor
-                                    </div>
-                                </div>
-                                <button type="button" class="btn btn-secondary w-100 rounded-0" onclick="add_movie(event, this)">
-                                    ${_('Add')}
-                                </button>
-                            </div>
-                        </div>
+                        <button type="button" class="btn btn-secondary dropdown-toggle w-75 rounded-0" onclick="add_movie_settings(event, this)">
+                            ${_('Add')}
+                        </button>
                         <button class="btn btn-secondary w-25 rounded-0 show_details" onclick="show_details(event, this)">
                             <i class="mdi mdi-open-in-new"></i>
                         </button>
+                        <div class="add-movie-form">
+                            <div>
+                                <button type="button" class="quality_profile btn btn-secondary dropdown-toggle w-100 rounded-0" data-toggle="dropdown">
+                                    ${next((profile[0] for profile in profiles if profile[1]), _('Quality Profile'))}
+                                </button>
+                                <div class="dropdown-menu">
+                                    %for profile in profiles:
+                                    <a class="dropdown-item ${'mdi mdi-star' if profile[1] else ''}" href="#" onclick="select_item(event, this)">
+                                        ${profile[0]}
+                                    </a>
+                                    %endfor
+                                </div>
+                            </div>
+                            <div>
+                                <button type="button" class="category btn btn-secondary dropdown-toggle w-100 rounded-0" data-toggle="dropdown">
+                                    ${_('Default')}
+                                </button>
+                                <div class="dropdown-menu">
+                                    <a class="dropdown-item mdi mdi-star" href="#" onclick="select_item(event, this)">
+                                        ${_('Default')}
+                                    </a>
+                                    %for category in categories:
+                                    <a class="dropdown-item" href="#" onclick="select_item(event, this)">
+                                        ${category}
+                                    </a>
+                                    %endfor
+                                </div>
+                            </div>
+                            <button type="button" class="btn btn-secondary w-100 rounded-0" onclick="add_movie(event, this)">
+                                ${_('Add Movie')}
+                            </button>
+                        </div>
                     </div>
                     <div class="card-body">
                         <span class="title px-2">{title}</span>


### PR DESCRIPTION
I never liked the way I changed add dropdown with quality, to slide down with 2 dropdowns, because it was moving other movie boxes down, if there were more than one row.

I have changed a bit so quick add form is open floating.
![image](https://user-images.githubusercontent.com/20515/66346359-4d00d100-e952-11e9-8c33-a08f20679ea3.png)
