### PR TITLE
fuzzy search with like in postprocessing when nothing matches

### DIFF
--- a/core/postprocessing.py
+++ b/core/postprocessing.py
@@ -314,7 +314,12 @@ class Postprocessing(object):
                 if result:
                     logging.info('Found match for {} in releases.'.format(fname))
                 else:
-                    logging.info('Unable to find local release info by release name.')
+                    logging.info('Unable to find local release info by release name, trying fuzzy search.')
+                    result = core.sql.get_single_search_result('title', re.sub(r'[\[\]\(\)\-.:]', '_', fname), like=True)
+                    if result:
+                        logging.info('Found match for {} in releases.'.format(fname))
+                    else:
+                        logging.info('Unable to find local release info by release name.')
 
         # if we found it, get local movie info
         if result:

--- a/core/scheduler.py
+++ b/core/scheduler.py
@@ -86,7 +86,7 @@ class PostProcessingScan(object):
             le = datetime.datetime.strptime(t, '%Y-%m-%d %H:%M:%S')
             threshold = time.mktime(le.timetuple())
 
-            logging.info('Scanning for new files only (last scan: {}).'.format(d, le))
+            logging.info('Scanning {} for new files only (last scan: {}).'.format(d, le))
 
             for i in os.listdir(d):
                 f = os.path.join(d, i)

--- a/core/sqldb.py
+++ b/core/sqldb.py
@@ -614,7 +614,7 @@ class SQL(object):
         else:
             return True
 
-    def get_single_search_result(self, idcol, idval):
+    def get_single_search_result(self, idcol, idval, like=False):
         ''' Gets single search result
         idcol (str): identifying column
         idval (str): identifying value
@@ -626,7 +626,8 @@ class SQL(object):
 
         logging.debug('Retrieving search result details for {}.'.format(idval.split('&')[0]))
 
-        command = ['SELECT * FROM SEARCHRESULTS WHERE {}="{}" ORDER BY score DESC, size DESC'.format(idcol, idval)]
+        operator = 'LIKE' if like else '='
+        command = ['SELECT * FROM SEARCHRESULTS WHERE {} {} "{}" ORDER BY score DESC, size DESC'.format(idcol, operator, idval)]
 
         result = self.execute(command)
 


### PR DESCRIPTION
When nothing matches with guid, downloadid and exact title in
searchresults, match with like replacing special characters []()-.:
with 1 character wildcard.

Fixes #48 