### PR TITLE
Possible fix for load_start error under rTorrent 0.9.7+

### DIFF
--- a/core/downloaders/rTorrentHTTP.py
+++ b/core/downloaders/rTorrentHTTP.py
@@ -73,7 +73,7 @@ def add_torrent(data):
         if conf['addpaused']:
             client.load(data['torrentfile'])
         else:
-            client.load_start(data['torrentfile'])
+            client.load.start(data['torrentfile'])
 
         if conf['label'] and downloadid:
             t = 0


### PR DESCRIPTION
Should fix xmlrpc.client.Fault: <Fault -506: "Method 'load_start' not defined"> error based on [this](https://github.com/rakshasa/rtorrent/wiki/rTorrent-0.9-Comprehensive-Command-list-(WIP)#comprehensive-list-of-rtorrent-09-commands) documentation. Fixes #127 