### PR TITLE
Fix broken scroll when adding a movie from feed, #142

### DIFF
--- a/static/css/add_movie.css
+++ b/static/css/add_movie.css
@@ -1,29 +1,30 @@
 ul.nav.nav-pills {
-    justify-content: space-between;
+  justify-content: space-between;
 }
 
 ul.nav.nav-pills li {
-    flex: 1;
-    text-align: center;
-    margin-bottom: 0;
+  flex: 1;
+  text-align: center;
+  margin-bottom: 0;
 }
 
 @media (max-width: 820px) {
-   ul.nav.nav-pills li {
-        width: calc(25% - 15px);
-        flex: auto;
-        margin-bottom: 10px;
-    }
+  ul.nav.nav-pills li {
+    width: calc(25% - 15px);
+    flex: auto;
+    margin-bottom: 10px;
+  }
 }
 
 @media (max-width: 560px) {
-    ul.nav.nav-pills li {
-        width: calc(50% - 15px);
-    }
+  ul.nav.nav-pills li {
+    width: calc(50% - 15px);
+  }
 }
 
 ul#movies {
   max-width: 100%;
+  max-height: inherit !important;
   width: 100%;
   justify-content: flex-start;
   display: inline-flex;
@@ -37,110 +38,110 @@ ul#movies {
 }
 
 ul#movies li {
-    width: calc(20% - 15px);
-    margin: 1em 0.5em 0;
-    text-align: center;
+  width: calc(20% - 15px);
+  margin: 1em 0.5em 0;
+  text-align: center;
 }
 
 ul#movies li {
-    width: calc(20% - 15px);
-    margin: 1em 0.5em 0;
-    text-align: center;
+  width: calc(20% - 15px);
+  margin: 1em 0.5em 0;
+  text-align: center;
 }
 
 @media (max-width: 820px) {
-    ul#movies li {
-        width: calc(25% - 15px);
-    }
+  ul#movies li {
+    width: calc(25% - 15px);
+  }
 }
 
 @media (max-width: 560px) {
-    ul#movies li {
-        width: calc(50% - 15px);
-    }
+  ul#movies li {
+    width: calc(50% - 15px);
+  }
 }
 
 ul#movies {
-    max-width: 960px;
+  max-width: 960px;
 }
 
-.card-body{
-    padding: 0.5em 0.25em;
+.card-body {
+  padding: 0.5em 0.25em;
 }
 
 .card-body span.score,
-.card-body span.year{
-    font-size: 0.8em;
-    opacity: 0.6;
+.card-body span.year {
+  font-size: 0.8em;
+  opacity: 0.6;
 }
 
-.card .add-movie-form{
-    display: none;
-    width: 100%;
-    position: absolute;
-    top: 100%;
-    z-index: 1;
+.card .add-movie-form {
+  display: none;
+  width: 100%;
+  position: absolute;
+  top: 100%;
+  z-index: 1;
 }
 
-button.show_details{
-    padding: 0;
+button.show_details {
+  padding: 0;
 }
 
-div.movie span.title{
-    font-weight: 500;
+div.movie span.title {
+  font-weight: 500;
 }
 
-div.movie span.year{
-    opacity: 0.6;
+div.movie span.year {
+  opacity: 0.6;
 }
 
 /* details modal */
-div.modal-badges{
-    padding: 0.5em 1em;
+div.modal-badges {
+  padding: 0.5em 1em;
 }
 
-div.modal-badges > .badge{
-    font-size: 0.8em;
-    height: 1.75em;
-    line-height: 1.25em;
-    margin-bottom: .25rem;
-    font-weight: normal;
+div.modal-badges > .badge {
+  font-size: 0.8em;
+  height: 1.75em;
+  line-height: 1.25em;
+  margin-bottom: .25rem;
+  font-weight: normal;
 }
 
-div.modal-badges > .badge i.mdi{
-    vertical-align: unset;
+div.modal-badges > .badge i.mdi {
+  vertical-align: unset;
 }
 
-img.poster{
-    margin-bottom: 1em;
-    max-height: 18em;
+img.poster {
+  margin-bottom: 1em;
+  max-height: 18em;
 }
 
 preload-icon {
-    display: none;
+  display: none;
 }
 
 preload-icon.loading {
-    align-items: center;
-    display: flex;
-    height: 100%;
-    justify-content: center;
-    left: 0;
-    position: absolute;
-    top: 0;
-    width: 100%;
+  align-items: center;
+  display: flex;
+  height: 100%;
+  justify-content: center;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 100%;
 }
 
 preload-icon > .mdi {
-    font-size: 3em;
-    width: initial;
+  font-size: 3em;
+  width: initial;
 }
 
 iframe#trailer.unavailable {
-    background: url("../images/trailer_unavailable.png") no-repeat 50% 50%;
+  background: url("../images/trailer_unavailable.png") no-repeat 50% 50%;
 }
 
-div.modal-body p.plot{
-    text-indent: 1.5em;
-    margin-top: 1em;
+div.modal-body p.plot {
+  text-indent: 1.5em;
+  margin-top: 1em;
 }


### PR DESCRIPTION
Rather easy fix, for some reason when selecting an option, inline style max-height: 200% is applied to the movies list. As I'm not a back-end guy I have no idea which part of functionality adds that style, but I have overridden it from stylesheet in this commit with `max-height: inherit !important`.

See:
![Alt text](https://fileshare.servebeer.com/OnwTV.png "Screenshot")

If this ovveride is not optimal, please suggest an alternative as I know no other way.