### PR TITLE
Fix toolbar sorting nav alignment to container

### DIFF
--- a/static/css/themes/Default.css
+++ b/static/css/themes/Default.css
@@ -8052,3 +8052,35 @@ a.text-dark:hover, a.text-dark:focus {
     border: 1px solid #ddd
   }
 }
+
+/* Main toolbar alignment */
+#toolbar {
+  justify-content: space-between;
+}
+
+#toolbar > div.text-center {
+  flex: none;
+  max-width: 100%;
+}
+
+#toolbar > div {
+  flex: none;
+  max-width: 100%;
+  width: auto;
+}
+
+@media (max-width: 824px) {
+  #toolbar > div {
+    width: 100%;
+  }
+
+  body #toolbar .col-md-4.col-sm-6.order-md-3 {
+    text-align: left;
+  }
+}
+
+@media (max-width: 470px) {
+  body #toolbar .col-md-4.col-sm-6.order-md-3 .btn-group {
+    flex-wrap: wrap;
+  }
+}


### PR DESCRIPTION
The sorting toolbar is a little far off from the right side and is not equally fitter inside the container. This Pull Request fixes this, it adds `justify-content: space-between` value to the toolbar and aligns the columns correctly. There has been incorrect use of bootstrap HTML classes that causes this but as I'm not familiar with this stack and don't want to fiddle with markup, I decided to create a hotfix via CSS instead. I honestly do not undestand why you use this CSS framework but I guess you wanted to have some structure quickly :) I'm a full stylesheet dude and always keen on clean CSS and I think this would need a serious refactoring overall. It's "good enough" as is though, not sure if worth rewriting.

Wasn't sure what the SCSS files are for since there's not really any gulp.js SCSS to CSS build process or anything else of the sort.

Enough babbling, here's the patch. I hope you like it. Tested & working.