### PR TITLE
Fix deprecation warnings due to invalid escape sequences.

### DIFF
--- a/core/movieinfo.py
+++ b/core/movieinfo.py
@@ -61,9 +61,9 @@ class TheMovieDatabase(object):
 
         if re.match('^tt[0-9]{7,9}$', search_term):
             movies = TheMovieDatabase._search_imdbid(search_term)
-        elif re.match('^imdb:\s*tt[0-9]{7,8}\s*$', search_term):
+        elif re.match(r'^imdb:\s*tt[0-9]{7,8}\s*$', search_term):
             movies = TheMovieDatabase._search_imdbid(search_term[5:].strip())
-        elif re.match('^tmdb:\s*[0-9]+\s*$', search_term):
+        elif re.match(r'^tmdb:\s*[0-9]+\s*$', search_term):
             movies = TheMovieDatabase._search_tmdbid(search_term[5:].strip())
             if movies and 'status' in movies[0]:
                 # watcher thinks movie is already added when it has status, so we don't want status in search result

--- a/core/postprocessing.py
+++ b/core/postprocessing.py
@@ -591,7 +591,7 @@ class Postprocessing(object):
             logging.info('Renamer disabled.')
             result['tasks']['renamer'] = {'enabled': False}
 
-        if data.get('imdbid') and data['imdbid'] is not 'N/A':
+        if data.get('imdbid') and data['imdbid'] != 'N/A':
             core.sql.update('MOVIES', 'finished_file', result['data'].get('finished_file'), 'imdbid', data['imdbid'])
 
         # Delete leftover dir. Skip if file links are enabled or if mover disabled/failed

--- a/core/searcher.py
+++ b/core/searcher.py
@@ -69,7 +69,7 @@ def search_all():
     if not movies:
         return
 
-    backlog_movies = [i for i in movies if i['backlog'] != 1 and i['status'] is not 'Disabled' and Manage.verify(i, today=today)]
+    backlog_movies = [i for i in movies if i['backlog'] != 1 and i['status'] != 'Disabled' and Manage.verify(i, today=today)]
     if backlog_movies:
         logging.debug('Backlog movies: {}'.format(', '.join(i['title'] for i in backlog_movies)))
         for movie in backlog_movies:


### PR DESCRIPTION
Fixes below warnings in Python 3.8

```
find core -iname '*.py' | xargs -P4 -I{} python3 -Wall -m py_compile {}  | grep -v lib
core/movieinfo.py:64: DeprecationWarning: invalid escape sequence \s
  elif re.match('^imdb:\s*tt[0-9]{7,8}\s*$', search_term):
core/movieinfo.py:66: DeprecationWarning: invalid escape sequence \s
  elif re.match('^tmdb:\s*[0-9]+\s*$', search_term):
core/searcher.py:72: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  backlog_movies = [i for i in movies if i['backlog'] != 1 and i['status'] is not 'Disabled' and Manage.verify(i, today=today)]
core/postprocessing.py:594: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if data.get('imdbid') and data['imdbid'] is not 'N/A':
```