### PR TITLE
Adds support for setting timezone in docker container

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.10.3
 
 ENV LANG="en_US.utf8" APP_NAME="watcher3" IMG_NAME="watcher3" PATH="/opt/watcher3:$PATH"
 
-RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec
+RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec tzdata
 
 RUN mkdir /opt/$APP_NAME && cd /opt/$APP_NAME && git clone https://github.com/barbequesauce/Watcher3 .
 

--- a/Docker/Dockerfile.aarch64
+++ b/Docker/Dockerfile.aarch64
@@ -3,7 +3,7 @@ COPY qemu-aarch64-static /usr/bin/
 
 ENV LANG="en_US.utf8" APP_NAME="watcher3" IMG_NAME="watcher3" PATH="/opt/watcher3:$PATH"
 
-RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec
+RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec tzdata
 
 RUN mkdir /opt/$APP_NAME && cd /opt/$APP_NAME && git clone https://github.com/barbequesauce/Watcher3 .
 

--- a/Docker/Dockerfile.armhf
+++ b/Docker/Dockerfile.armhf
@@ -3,7 +3,7 @@ COPY qemu-arm-static /usr/bin/
 
 ENV LANG="en_US.utf8" APP_NAME="watcher3" IMG_NAME="watcher3" PATH="/opt/watcher3:$PATH"
 
-RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec
+RUN apk add --no-cache bash curl git nano vim ca-certificates python3 su-exec tzdata
 
 RUN mkdir /opt/$APP_NAME && cd /opt/$APP_NAME && git clone https://github.com/barbequesauce/Watcher3 .
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Refer to the wiki for more information about post-processing, start scripts, and
 ## Latest
 
 Added ARM 32 and 64 bit docker images.
+Added docker timezone support.
  
 ## Installation
 
@@ -179,4 +180,22 @@ So for example:
   barbequesauce/watcher3:armhf
 ``` 
 
-You may also wish to checkout ellnic's repo: https://github.com/ellnic/Watcher3 [this is considered unstable at times please see warning in readme]
+### Docker Timezone
+
+By default, the Alpine docker images use UTC. You can set the timezone using the `TZ` env variable and your TZ code from the database [here](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
+
+For example:
+
+
+```
+    docker run -d \
+  --name=watcher3 \
+  -v /path/to/config/:/config \
+  -v /path/to/downloads/:/downloads \
+  -v /path/to/movies/:/movies \
+  -e UMASK_SET=022 \
+  -e APP_UID=1000 -e APP_GID=1000 \
+  -e TZ="Europe/London" \
+  -p 9090:9090 \
+  barbequesauce/watcher3:armhf
+``` 


### PR DESCRIPTION
Adds the tzdata package to the docker build so the tz env variable can be used.

Added info to Readme.

Closes #187 